### PR TITLE
gh issue 22: ghcr is more restrictive than zot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+cert
 output
 token.sh
 .env


### PR DESCRIPTION
* can not add layer to manifest if blob is not uploaded to registry. this should also be a bug in zot, but zot allows it. This commit fixes this, by uploading the blob before uploading the modified manifest

* ghcr does not allow to download manifests from blobs api, it needs an accept header and the equest must go against manifests endpoint with a GET request
